### PR TITLE
fix: 修复访问控制模式部分开放无法保存密码问题

### DIFF
--- a/app/public/js/admin.js
+++ b/app/public/js/admin.js
@@ -1042,7 +1042,7 @@ async function saveSettings(event) {
         }
 
         // 仅当访问控制为部分开放并且输入了密码时更新访客密码
-        if (accessControl === "partial" && guestPassword) {
+        if (accessControl === "restricted" && guestPassword) {
             data.guestPassword = guestPassword;
         }
 


### PR DESCRIPTION
## 成因

![PixPin_2025-04-13_14-46-34](https://github.com/user-attachments/assets/f01011c4-5b4e-4cbc-8f9c-63a0bbd2d4ca)

查看了下请求数据：

![PixPin_2025-04-13_14-48-45](https://github.com/user-attachments/assets/73614093-57cb-457d-9d77-64a2574da6a5)

## 定位了一下代码问题

![image](https://github.com/user-attachments/assets/ce3e5c19-8b64-449d-83a8-c21243d42184)

## 最后修改后解决了

![PixPin_2025-04-13_15-03-06](https://github.com/user-attachments/assets/bbe244d9-e04e-4cdc-bd89-5853fe04603f)
